### PR TITLE
Updated manual entry form so that every manual entry user makes is in the manual entries list. ALSO updated way an item is deleted from a list.

### DIFF
--- a/MediaShelfApp/MediaShelfApp/ListView.cs
+++ b/MediaShelfApp/MediaShelfApp/ListView.cs
@@ -319,7 +319,8 @@ namespace MediaShelfApp
 
             if (areYouSure == DialogResult.Yes)
             {
-                int[] id = GetItemID(title, creator);
+                int listID = getListID(list);
+                int[] id = GetItemID(title, creator, listID);
                 DeleteItem(id[0], id[1]);
                 DeleteNotes(id[0], id[1]);
 
@@ -450,8 +451,8 @@ namespace MediaShelfApp
             window.Show();
         }
 
-        // Returns the items ID and API ID (primary key) from title and creator
-        private int[] GetItemID(string title, string creator)
+        // Returns the items ID and API ID (primary key) from title, creator, and list id
+        private int[] GetItemID(string title, string creator, int listID)
         {
             int[] item = { 0, 0 };
             try
@@ -465,11 +466,13 @@ namespace MediaShelfApp
                                          ITEM_API
                                          FROM ITEMS
                                          WHERE ITEM_CREATOR = @bind2
-                                         AND ITEM_TITLE = @bind1";
+                                         AND ITEM_TITLE = @bind1
+                                         AND ITEM_LIST_ID = @bind3";
 
                 // Parameterize the variables for system security
                 cmdGetID.Parameters.AddWithValue("@bind1", title);
                 cmdGetID.Parameters.AddWithValue("@bind2", creator);
+                cmdGetID.Parameters.AddWithValue("@bind3", listID);
 
                 // Execute query
                 SqlDataReader reader = cmdGetID.ExecuteReader();
@@ -605,6 +608,33 @@ namespace MediaShelfApp
 
             dbConnection.Close();
             return 0;
+        }
+
+        // gets the list id of the current list
+        private int getListID(string listName)
+        {
+            int listID = -1;
+
+            // open connection to database
+            dbConnection.Open();
+
+            // find the list id in database
+            SqlCommand cmdGetListID = dbConnection.CreateCommand();
+            cmdGetListID.CommandText = @"SELECT LIST_ID FROM LIST WHERE LIST_NAME = @bind1";
+            cmdGetListID.Parameters.AddWithValue("@bind1", list);
+            cmdGetListID.ExecuteNonQuery();
+            cmdGetListID.Dispose();
+
+            // get the list id from database
+            SqlDataReader reader = cmdGetListID.ExecuteReader();
+            if (reader.Read())
+                listID = int.Parse(reader[0].ToString());
+            reader.Close();
+
+            // close connection to database
+            dbConnection.Close();
+
+            return listID;
         }
     }
 }

--- a/MediaShelfApp/MediaShelfApp/Manual_Entry_Form.cs
+++ b/MediaShelfApp/MediaShelfApp/Manual_Entry_Form.cs
@@ -152,9 +152,15 @@ namespace MediaShelfApp
                 cmdInsertMedia.Parameters.AddWithValue("@list", listID);
                 cmdInsertMedia.Parameters.AddWithValue("@genre", genre);
 
-
                 // Execute the insertion query
                 cmdInsertMedia.ExecuteNonQuery();
+
+                // Make sure item is added to manual entries list
+                if (listID != 0)
+                {
+                    cmdInsertMedia.Parameters[cmdInsertMedia.Parameters.IndexOf("@list")].Value = 0;
+                    cmdInsertMedia.ExecuteNonQuery();
+                }
 
                 // Close connection and dispose of the command
                 dbConnection.Close();


### PR DESCRIPTION
Specifically, updated GetItemID() in ListView so that one of the formal parameters is the current list's id number (and to find the list id number, I also added a function that does that). 

Previously, the item id that was returned was the first that matched the title and creator, but this meant that if a user had the same item (manual or not) in a different list, then the item would be deleted from the list it was first added to, not necessarily the list the item is being deleted from.

Now the list the item is deleted from is guaranteed to be the same list the user is deleting from.